### PR TITLE
removed "s" from the base platform regex

### DIFF
--- a/giturlparse/__init__.py
+++ b/giturlparse/__init__.py
@@ -6,7 +6,7 @@ from .result import GitUrlParsed
 
 __author__ = 'Iacopo Spalletti'
 __email__ = 'i.spalletti@nephila.it'
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 
 def parse(url, check_domain=True):

--- a/giturlparse/platforms/base.py
+++ b/giturlparse/platforms/base.py
@@ -13,10 +13,10 @@ class BasePlatform(object):
     }
 
     PATTERNS = {
-        'ssh': r"(?P<_user>.+)s@(?P<domain>.+)s:(?P<repo>.+)s.git",
-        'http': r"http://(?P<domain>.+)s/(?P<repo>.+)s.git",
-        'https': r"https://(?P<domain>.+)s/(?P<repo>.+)s.git",
-        'git': r"git://(?P<domain>.+)s/(?P<repo>.+)s.git"
+        'ssh': r"(?P<_user>.+)@(?P<domain>.+):(?P<repo>.+).git",
+        'http': r"http://(?P<domain>.+)/(?P<repo>.+).git",
+        'https': r"https://(?P<domain>.+)/(?P<repo>.+).git",
+        'git': r"git://(?P<domain>.+)/(?P<repo>.+).git"
     }
 
     # None means it matches all domains


### PR DESCRIPTION
this bug was only in the base project. it matched only urls where each token ends with an "s"