### PR TITLE
Fix github ssh url regex

### DIFF
--- a/giturlparse/platforms/github.py
+++ b/giturlparse/platforms/github.py
@@ -8,9 +8,9 @@ class GitHubPlatform(BasePlatform):
             r"(?P<pathname>/(?P<owner>[^/]+?)/(?P<repo>[^/]+?)(?:\.git)?(?P<path_raw>(/blob/|/tree/).+)?)$"
         ),
         "ssh": (
-            r"(?P<protocols>(git\+)?(?P<protocol>ssh))?(://)?git@(?P<domain>.+?)(?P<pathname>(:|/)"
-            r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)"
-            r"(?P<path_raw>(/blob/|/tree/).+)?)$"
+            r"(?P<protocols>(git\+)?(?P<protocol>ssh))?(://)?git@(?P<domain>.+)(?P<pathname>(:|/)"
+            r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?"
+            r"(?P<path_raw>/(blob/|tree/|).*)?)$"
         ),
         "git": (
             r"(?P<protocols>(?P<protocol>git))://(?P<domain>.+?)"


### PR DESCRIPTION
# Description

Fix Github ssh url regex

## References

This fix adds support to the following urls:
- `git@github.com/nephila/giturlparse`
- `git@github.com/nephila/giturlparse/`
- `git@github.com/nephila/giturlparse.git/`

# Checklist

* [ ] Code lint checked via `inv lint`
* [] Tests added
