### PR TITLE
Comment out print statements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.11.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.?)(?P<release>[a-z]*)(?P<relver>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{relver}
 	{major}.{minor}.{patch}
 commit = True
@@ -12,7 +12,7 @@ message = Release {new_version}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	a
 	b

--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -35,7 +35,7 @@ def parse(url, check_domain=True):
 
             # Skip if not matched
             if not match:
-                print("[{}] URL: {} dit not match {}".format(name, url, regex.pattern))
+                # print("[{}] URL: {} dit not match {}".format(name, url, regex.pattern))
                 continue
 
             # Skip if domain is bad

--- a/giturlparse/platforms/base.py
+++ b/giturlparse/platforms/base.py
@@ -35,7 +35,7 @@ class BasePlatform:
 
     @staticmethod
     def clean_data(data):
-        print(data)
+        # print(data)
         data["path"] = ""
         data["branch"] = ""
         data["protocols"] = list(filter(lambda x: x, data.get("protocols", "").split("+")))


### PR DESCRIPTION
# Description

Describe:

* Print statements were left in which pollutes stdout for users. This breaks tests of users which use regex to find matching strings in stdout.

## References

Fix #66 

# Checklist

* [x] Code lint checked via `inv lint`
* [ ] ~~Tests added~~
