### PR TITLE
Fix BitBucket regex

### DIFF
--- a/giturlparse/platforms/bitbucket.py
+++ b/giturlparse/platforms/bitbucket.py
@@ -4,7 +4,7 @@ from .base import BasePlatform
 class BitbucketPlatform(BasePlatform):
     PATTERNS = {
         "https": (
-            r"(?P<protocols>(git\+)?(?P<protocol>https))://(?P<_user>.+)@(?P<domain>.+?)"
+            r"(?P<protocols>(git\+)?(?P<protocol>https))://(?P<_user>(.+)?)@(?P<domain>.+?)"
             r"(?P<pathname>/(?P<owner>.+)/(?P<repo>.+?)(?:\.git)?)$"
         ),
         "ssh": (
@@ -16,5 +16,5 @@ class BitbucketPlatform(BasePlatform):
         "https": r"https://%(owner)s@%(domain)s/%(owner)s/%(repo)s%(dot_git)s",
         "ssh": r"git@%(domain)s:%(owner)s/%(repo)s%(dot_git)s",
     }
-    DOMAINS = ("bitbucket.org",)
+    DOMAINS = ("bitbucket.org", "bitbucket.com")
     DEFAULTS = {"_user": "git"}


### PR DESCRIPTION
# Description
This fixes the BitBucket regex so username@ is not required, and adds `bitbucket.com` as a recognised domain.

## References

Fixes #107

# Checklist

* [ ] Code lint checked via `inv lint`
* [ ] Tests added
