### PR TITLE
Fix path/branch extraction removing every /blob/ and /tree/ marker, not just the leading one

### DIFF
--- a/changes/150.bugfix
+++ b/changes/150.bugfix
@@ -1,0 +1,1 @@
+Fix ``path`` and ``branch`` extraction removing *every* ``/blob/`` and ``/tree/`` occurrence instead of only the leading marker, which corrupted file paths and branch names containing those segments.

--- a/giturlparse/platforms/github.py
+++ b/giturlparse/platforms/github.py
@@ -34,7 +34,7 @@ class GitHubPlatform(BasePlatform):
     def clean_data(data):
         data = BasePlatform.clean_data(data)
         if data["path_raw"].startswith("/blob/"):
-            data["path"] = data["path_raw"].replace("/blob/", "")
+            data["path"] = data["path_raw"][len("/blob/") :]
         if data["path_raw"].startswith("/tree/"):
-            data["branch"] = data["path_raw"].replace("/tree/", "")
+            data["branch"] = data["path_raw"][len("/tree/") :]
         return data

--- a/giturlparse/platforms/gitlab.py
+++ b/giturlparse/platforms/gitlab.py
@@ -38,9 +38,9 @@ class GitLabPlatform(BasePlatform):
     def clean_data(data):
         data = BasePlatform.clean_data(data)
         if data["path_raw"].startswith("/blob/"):
-            data["path"] = data["path_raw"].replace("/blob/", "")
+            data["path"] = data["path_raw"][len("/blob/") :]
         if data["path_raw"].startswith("/-/blob/"):
-            data["path"] = data["path_raw"].replace("/-/blob/", "")
+            data["path"] = data["path_raw"][len("/-/blob/") :]
         if data["path_raw"].startswith("/-/tree/"):
-            data["branch"] = data["path_raw"].replace("/-/tree/", "")
+            data["branch"] = data["path_raw"][len("/-/tree/") :]
         return data

--- a/giturlparse/tests/test_parse.py
+++ b/giturlparse/tests/test_parse.py
@@ -484,6 +484,80 @@ VALID_PARSE_URLS = (
     (
         "HTTPS",
         (
+            # Regression: a file path that itself contains a "blob" directory must
+            # not have the inner "/blob/" stripped (only the leading marker).
+            "https://github.com/nephila/giturlparse/blob/master/giturlparse/blob/data.py",
+            {
+                "host": "github.com",
+                "resource": "github.com",
+                "port": "",
+                "user": "git",
+                "owner": "nephila",
+                "repo": "giturlparse",
+                "name": "giturlparse",
+                "groups": [],
+                "path": "master/giturlparse/blob/data.py",
+                "path_raw": "/blob/master/giturlparse/blob/data.py",
+                "pathname": "/nephila/giturlparse/blob/master/giturlparse/blob/data.py",
+                "branch": "",
+                "protocol": "https",
+                "protocols": ["https"],
+                "platform": "github",
+            },
+        ),
+    ),
+    (
+        "HTTPS",
+        (
+            # Regression: a branch name containing "/tree/" must be preserved
+            # in full rather than having every "/tree/" removed.
+            "https://github.com/nephila/giturlparse/tree/feature/tree/x",
+            {
+                "host": "github.com",
+                "resource": "github.com",
+                "port": "",
+                "user": "git",
+                "owner": "nephila",
+                "repo": "giturlparse",
+                "name": "giturlparse",
+                "groups": [],
+                "path": "",
+                "path_raw": "/tree/feature/tree/x",
+                "pathname": "/nephila/giturlparse/tree/feature/tree/x",
+                "branch": "feature/tree/x",
+                "protocol": "https",
+                "protocols": ["https"],
+                "platform": "github",
+            },
+        ),
+    ),
+    (
+        "HTTPS",
+        (
+            # Regression (GitLab): inner "/blob/" in the file path must survive.
+            "https://gitlab.com/nephila/giturlparse/-/blob/master/giturlparse/blob/data.py",
+            {
+                "host": "gitlab.com",
+                "resource": "gitlab.com",
+                "port": "",
+                "user": "git",
+                "owner": "nephila",
+                "repo": "giturlparse",
+                "name": "giturlparse",
+                "groups": [],
+                "path": "master/giturlparse/blob/data.py",
+                "path_raw": "/-/blob/master/giturlparse/blob/data.py",
+                "pathname": "/nephila/giturlparse/-/blob/master/giturlparse/blob/data.py",
+                "branch": "",
+                "protocol": "https",
+                "protocols": ["https"],
+                "platform": "gitlab",
+            },
+        ),
+    ),
+    (
+        "HTTPS",
+        (
             "https://github.com/nephila/giturlparse/tree/feature/py37",
             {
                 "host": "github.com",


### PR DESCRIPTION
# Description

`path` and `branch` are extracted from the matched URL by removing the leading
`/blob/`, `/tree/`, `/-/blob/` or `/-/tree/` marker. The code did this with
`str.replace(marker, "")`, which removes **every** occurrence of the marker, not
just the leading one. When the file path or branch name legitimately contains the
same segment again, the result is silently corrupted.

For example:

```python
>>> import giturlparse
>>> giturlparse.parse("https://github.com/owner/repo/blob/main/src/blob/utils.py").path
'main/srcutils.py'        # expected: 'main/src/blob/utils.py'
>>> giturlparse.parse("https://github.com/owner/repo/tree/feature/tree/x").branch
'featurex'                # expected: 'feature/tree/x'
```

The leading marker is already guaranteed by the preceding `startswith(...)` check,
so the fix is to slice off exactly that prefix instead of calling `replace`:

```python
data["path"] = data["path_raw"][len("/blob/"):]
```

Slicing is used (rather than `str.removeprefix`) to remain compatible with the
declared `python_requires = >=3.8`.

Fixed in both the GitHub and GitLab platforms.

## References

No existing issue.

# Checklist

* [x] Code lint checked via `inv lint` (ruff, black, isort all clean on the changed files)
* [x] Tests added (regression cases for nested `/blob/` paths and `/tree/` branch names on both GitHub and GitLab; verified to fail on the previous code and pass with the fix)
* [x] Changelog fragment added under `changes/`
